### PR TITLE
Add Docker

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,23 @@
+name: ci
+
+on:
+  push:
+    branches:
+      - "main"
+
+jobs:
+  build-and-push-docker-image:
+    name: Build and push the Docker image
+    runs-on: debian-latest
+    steps:
+      - name: Login to GitHub Packages Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build
+        uses: docker/build-push-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+FROM rust:alpine as builder
+# Workaround "cannot find crti.o"
+RUN apk add --no-cache musl-dev
+WORKDIR /app
+# First, only copy over the Cargo manifests, and do a build with a dummy
+# main.rs. This way, Docker can cache all of this, and only actually download
+# and build those depepndencies once. This is nice, because otherwise it's
+# quite slow.
+COPY Cargo.toml Cargo.lock .
+RUN mkdir src && echo "fn main() { }" > src/main.rs
+RUN cargo build --release
+RUN rm -r src/
+# The above should get cached; but the below steps will be executed each
+# time you change the source code and do 'docker build'.
+COPY . .
+RUN cargo build --release
+RUN strip target/release/tidy
+
+FROM scratch
+COPY --from=builder /app/target/release/tidy /bin/tidy
+ENTRYPOINT ["/bin/tidy"]
+
+# Add some metadata about the image, for extra neatness.
+LABEL org.opencontainers.image.title="tidy" \
+      org.opencontainers.image.description="A command-line tool for combining and cleaning large word list files" \
+      org.opencontainers.image.url="https://github.com/sts10/tidy" \
+      org.opencontainers.image.authors="Sam Schlinkert <sschlinkert@gmail.com" \
+      org.opencontainers.image.licenses="MIT"


### PR DESCRIPTION
This adds a Dockerfile that can be used for building Docker images, like this:

```
$ docker build --tag tidy .
[1/2] STEP 1/10: FROM rust:alpine AS builder
<...lots of output, hopefully everything succeeds...>
Successfully tagged localhost/tidy:latest
<long hash string>
```

This will be kinda slow the first time, when Cargo has to refresh crates.io index and download and build all those dependencies, but the Dockerfile is written in a way that caches these between builds (unless `Cargo.toml` or `Cargo.lock` change...), so the following times should be a lot faster.

The resulting Docker image is only 1.25 MB in size (tidy is built with `--release` and `strip`ped), and only contains the `/bin/tidy` executable, nothing else.

<details>
<summary>See for yourself</summary>

Following [this StackOverflow comment](https://stackoverflow.com/a/53481010/2750624):

```
$ docker create --name="tmp_$$" tidy
bb3e95eab832f5735eae8f4f5c68bdeb6c05da39ae31826f7304d42959b652c9
$ docker export tmp_$$ | tar t
bin/
bin/tidy
$ docker rm tmp_$$
```

</details>

You can run the built image with e.g.

```
$ docker run --rm --tty tidy --version
tidy 0.2.75
```

See the Docker docs for more info on building and running images.

The second commit attempts to add a GitHub actions script that will make GitHub automatically build this Docker image (for both x86-64 and arm64) each time you push to the `main` branch, and publish this image in GitHub's Docker container registry, so that end users don't even have to build the images themselves, they should be able to just do:

```
$ docker run --whatever-flags ghcr.io/sts10/tidy
```

...if it works, that is. I can't verify whether it does, since GitHub doesn't seem to want to allocate any workers to my workflow, welp. Maybe you'll get more lucky.

> **Note**
> I'm actually using [Podman](https://podman.io/whatis.html), not Docker. So if you are using Docker proper, output on your machine may look a little bit different.