### PR TITLE
Gives user the choice of which Unicode normalization form to use

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -632,7 +632,7 @@ dependencies = [
 
 [[package]]
 name = "tidy"
-version = "0.2.79"
+version = "0.2.80"
 dependencies = [
  "clap",
  "icu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tidy"
-version = "0.2.79"
+version = "0.2.80"
 authors = ["sts10 <sschlinkert@gmail.com>"]
 edition = "2021"
 

--- a/readme.markdown
+++ b/readme.markdown
@@ -94,9 +94,9 @@ Options:
           Do NOT sort outputted list alphabetically. Preserves original list order. Note that 
           duplicates lines and blank lines will still be removed
 
-  -z, --normalize
-          Normalize Unicode of all characters of all words. Uses Unicode Normalization Form C. 
-          May negatively affect Tidy's performance
+  -z, --normalize <NORMALIZATION_FORM>
+          Normalize Unicode of all characters of all words. Accepts nfc, nfd, nfkc, or nfkd 
+          (case insensitive). May negatively affect Tidy's performance
 
   -l, --lowercase
           Lowercase all words on new list

--- a/readme.markdown
+++ b/readme.markdown
@@ -94,7 +94,7 @@ Options:
           Do NOT sort outputted list alphabetically. Preserves original list order. Note that 
           duplicates lines and blank lines will still be removed
 
-  -z, --normalize <NORMALIZATION_FORM>
+  -z, --normalization-form <NORMALIZATION_FORM>
           Normalize Unicode of all characters of all words. Accepts nfc, nfd, nfkc, or nfkd 
           (case insensitive). May negatively affect Tidy's performance
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub struct TidyRequest {
     pub sort_alphabetically: bool,
     pub ignore_after_delimiter: Option<char>,
     pub ignore_before_delimiter: Option<char>,
-    pub normalize: Option<String>,
+    pub normalization_form: Option<String>,
     pub to_lowercase: bool,
     pub should_straighten_quotes: bool,
     pub should_remove_prefix_words: bool,
@@ -138,8 +138,9 @@ pub fn tidy_list(req: TidyRequest) -> Vec<String> {
                 (None, None) => (word.to_string(), None, None, None),
             };
 
-        // Trim new word, then normalize unicode
-        new_word = match &req.normalize {
+        // Trim new word, then normalize unicode if user gave an
+        // nromalization form to use
+        new_word = match &req.normalization_form {
             Some(nf) => match normalize_unicode(new_word.trim(), &nf) {
                 Ok(word) => word,
                 Err(e) => panic!("{}", e),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ pub struct TidyRequest {
     pub sort_alphabetically: bool,
     pub ignore_after_delimiter: Option<char>,
     pub ignore_before_delimiter: Option<char>,
-    pub normalize: bool,
+    pub normalize: Option<String>,
     pub to_lowercase: bool,
     pub should_straighten_quotes: bool,
     pub should_remove_prefix_words: bool,
@@ -139,12 +139,16 @@ pub fn tidy_list(req: TidyRequest) -> Vec<String> {
             };
 
         // Trim new word, then normalize unicode
-        if req.normalize {
-            new_word = normalize_unicode(new_word.trim()).to_string();
-        } else {
-            // still need to trim
-            new_word = new_word.trim().to_string();
-        }
+        new_word = match &req.normalize {
+            Some(nf) => match normalize_unicode(new_word.trim(), &nf) {
+                Ok(word) => word,
+                Err(e) => panic!("{}", e),
+            },
+            None => {
+                // still need to trim
+                new_word.trim().to_string()
+            }
+        };
 
         // WORD MODIFICATIONS
         // For logic reasons, it's crucial that Tidy perform these word

--- a/src/list_manipulations.rs
+++ b/src/list_manipulations.rs
@@ -4,8 +4,19 @@ use memchr::memchr;
 use unicode_normalization::UnicodeNormalization;
 
 /// Normalize the Unicode of a string
-pub fn normalize_unicode(word: &str) -> String {
-    word.nfc().collect::<String>()
+/// See https://docs.rs/unicode-normalization/latest/unicode_normalization/trait.UnicodeNormalization.html#tymethod.nfc
+pub fn normalize_unicode(word: &str, nf: &str) -> Result<String, String> {
+    if nf.to_lowercase() == "nfc" {
+        Ok(word.nfc().collect::<String>())
+    } else if nf.to_lowercase() == "nfd" {
+        Ok(word.nfd().collect::<String>())
+    } else if nf.to_lowercase() == "nfkc" {
+        Ok(word.nfkc().collect::<String>())
+    } else if nf.to_lowercase() == "nfkd" {
+        Ok(word.nfkd().collect::<String>())
+    } else {
+        Err("Unknown Unicode normalizaion form received in arguments.\nPleasue use one of the following normalizaion forms: nfc, nfd, nfkc, or nfkd.".to_string())
+    }
 }
 
 use icu::collator::*;

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ struct Args {
     /// Normalize Unicode of all characters of all words. Uses Unicode Normalization Form C.
     /// May negatively affect Tidy's performance.
     #[clap(short = 'z', long = "normalize")]
-    normalize: bool,
+    normalize: Option<String>,
 
     /// Lowercase all words on new list
     #[clap(short = 'l', long = "lowercase")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,7 @@ struct Args {
     /// Normalize Unicode of all characters of all words. Accepts nfc, nfd, nfkc, or nfkd (case
     /// insensitive).
     /// May negatively affect Tidy's performance.
-    #[clap(short = 'z', long = "normalize")]
+    #[clap(short = 'z', long = "normalization-form")]
     normalization_form: Option<String>,
 
     /// Lowercase all words on new list

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,10 +58,11 @@ struct Args {
     #[clap(short = 'O', long = "no-sort")]
     no_alpha_sort: bool,
 
-    /// Normalize Unicode of all characters of all words. Uses Unicode Normalization Form C.
+    /// Normalize Unicode of all characters of all words. Accepts nfc, nfd, nfkc, or nfkd (case
+    /// insensitive).
     /// May negatively affect Tidy's performance.
     #[clap(short = 'z', long = "normalize")]
-    normalize: Option<String>,
+    normalization_form: Option<String>,
 
     /// Lowercase all words on new list
     #[clap(short = 'l', long = "lowercase")]
@@ -319,7 +320,7 @@ fn main() {
         ignore_after_delimiter: opt.ignore_after_delimiter,
         ignore_before_delimiter: opt.ignore_before_delimiter,
         to_lowercase: opt.to_lowercase,
-        normalize: opt.normalize,
+        normalization_form: opt.normalization_form,
         should_straighten_quotes: opt.straighten_quotes,
         should_remove_prefix_words: opt.remove_prefix_words,
         should_remove_suffix_words: opt.remove_suffix_words,

--- a/tests/list_manipulation_tests.rs
+++ b/tests/list_manipulation_tests.rs
@@ -571,9 +571,32 @@ mod list_manipulation_tests {
         assert_eq!(new_list, how_list_should_be_sorted);
     }
 
+    // this is really a WORD manipulation, so maybe should be in a
+    // different test file
     use tidy::list_manipulations::normalize_unicode;
     #[test]
     fn can_normalize_unicode_in_a_given_word() {
+        let word_with_combined_accents = "sécréter";
+        let word_with_two_char_accents = "sécréter";
+        assert_eq!(
+            word_with_combined_accents,
+            normalize_unicode(word_with_combined_accents, "nfc").unwrap()
+        );
+        assert_eq!(
+            word_with_combined_accents,
+            normalize_unicode(word_with_combined_accents, "nfkc").unwrap()
+        );
+        assert_eq!(
+            word_with_two_char_accents,
+            normalize_unicode(word_with_two_char_accents, "nfd").unwrap()
+        );
+        assert_eq!(
+            word_with_two_char_accents,
+            normalize_unicode(word_with_two_char_accents, "nfkd").unwrap()
+        );
+    }
+    #[test]
+    fn can_accurately_count_characters_after_a_nfc_normalization() {
         let word_with_combined_accents = "sécréter";
         let word_with_two_char_accents = "sécréter";
         assert_ne!(
@@ -581,10 +604,22 @@ mod list_manipulation_tests {
             word_with_two_char_accents.chars().count()
         );
         assert_eq!(
-            normalize_unicode(word_with_combined_accents)
+            normalize_unicode(word_with_combined_accents, "nfc")
+                .unwrap()
                 .chars()
                 .count(),
-            normalize_unicode(word_with_two_char_accents)
+            normalize_unicode(word_with_two_char_accents, "nfc")
+                .unwrap()
+                .chars()
+                .count()
+        );
+        assert_eq!(
+            normalize_unicode(word_with_combined_accents, "nfkd")
+                .unwrap()
+                .chars()
+                .count(),
+            normalize_unicode(word_with_two_char_accents, "nfkd")
+                .unwrap()
                 .chars()
                 .count()
         );


### PR DESCRIPTION
Solves #26 by making the user choose! This isn't _really_ as much of a cop out as you'd guess: Considering that Bitcoin's bips project enforces NFKD, if I did choose a default for Tidy, it'd have to be that. _BUT_ counting the length of NFKD words is a bit wonky, so I didn't want to make it the default normalization form for Tidy. 

Still have to solve #28 though... will attempt in separate PR. 