### PR TITLE
switches to unstable sort

### DIFF
--- a/src/list_manipulations.rs
+++ b/src/list_manipulations.rs
@@ -40,7 +40,7 @@ pub fn sort_carefully(list: Vec<String>, locale: Locale) -> Vec<String> {
     let collator_l2: Collator =
         Collator::try_new_unstable(&icu_testdata::unstable(), &locale.into(), options_l2).unwrap();
     let mut newly_sorted_list = list;
-    newly_sorted_list.sort_by(|a, b| collator_l2.compare(a, b));
+    newly_sorted_list.sort_unstable_by(|a, b| collator_l2.compare(a, b));
     newly_sorted_list
 }
 


### PR DESCRIPTION
I think it's safe to use an unstable sort when Tidy is alphabetizing words. 

Competing PR is #33 , where we'd use glidesort. 