### PR TITLE
Use match instead of if/else chain on normalize_unicode()

### DIFF
--- a/src/list_manipulations.rs
+++ b/src/list_manipulations.rs
@@ -7,16 +7,12 @@ use unicode_normalization::UnicodeNormalization;
 /// Normalize the Unicode of a string
 /// See https://docs.rs/unicode-normalization/latest/unicode_normalization/trait.UnicodeNormalization.html#tymethod.nfc
 pub fn normalize_unicode(word: &str, nf: &str) -> Result<String, String> {
-    if nf.to_lowercase() == "nfc" {
-        Ok(word.nfc().collect::<String>())
-    } else if nf.to_lowercase() == "nfd" {
-        Ok(word.nfd().collect::<String>())
-    } else if nf.to_lowercase() == "nfkc" {
-        Ok(word.nfkc().collect::<String>())
-    } else if nf.to_lowercase() == "nfkd" {
-        Ok(word.nfkd().collect::<String>())
-    } else {
-        Err("Unknown Unicode Normalization Form received in arguments.\nPlease use one of the following normalization forms: nfc, nfd, nfkc, or nfkd.".to_string())
+    match nf.to_lowercase().as_str() {
+        "nfc" => Ok(word.nfc().collect()),
+        "nfd" => Ok(word.nfd().collect()),
+        "nfkc" => Ok(word.nfkc().collect()),
+        "nfkd" => Ok(word.nfkd().collect()),
+        _ => Err("Unknown Unicode Normalization Form received in arguments.\nPlease use one of the following normalization forms: nfc, nfd, nfkc, or nfkd.".to_string()),
     }
 }
 


### PR DESCRIPTION
Hi! I just read your [article about sorting words](https://sts10.github.io/2023/01/29/sorting-words-alphabetically-rust.html). Thank you for seriously supporting non-English languages. I've used a mixed English/Spanish wordlist approach for generating passwords in the past (🤫), and i could see using a tool like Tidy for such word-twiddling task in the future :)

Anyways, the `normalized_unicode()` snippet made me think "hey isn't that a good candidate for a `match`?". And so here's the patch for that hehe. I hope this bike-shedding-ish change doesn't bother you.

The code should be equivalent, just a bit terser.

Also removed the explicit turbofish type parameters to `collect::<String>()`, which are not necessary since Rust is able to infer those from the function return type.

I tested this locally running `cargo test`, which passed, and also corroborated some tests covered this by removing a branch of the `match` and checking that the tests indeed failed :)

Cheers!