### PR TITLE
Perform Schlinkert pruning both forwards and reverse, picking whichever saves more words

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -690,7 +690,7 @@ dependencies = [
 
 [[package]]
 name = "tidy"
-version = "0.2.88"
+version = "0.2.90"
 dependencies = [
  "clap",
  "icu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tidy"
-version = "0.2.88"
+version = "0.2.90"
 authors = ["sts10 <sschlinkert@gmail.com>"]
 license = "MIT"
 edition = "2021"

--- a/readme.markdown
+++ b/readme.markdown
@@ -371,9 +371,11 @@ I occasionally [build releases](https://github.com/sts10/tidy/releases) of Tidy 
 
 ## For Tidy developers
 
-Run all code tests: `cargo test`
+* Run all code tests: `cargo test`
+* Generate docs: `cargo doc --document-private-items --no-deps`. Add `--open` flag to open docs after generation. Locally, docs are printed to `./target/doc/tidy/index.html`.
+* Check license compatibility of Tidy's dependencies: `cargo deny check licenses` (requires that you [have cargo-deny installed locally](https://github.com/EmbarkStudios/cargo-deny#install-cargo-deny))
 
-Generate docs: `cargo doc --document-private-items --no-deps`. Add `--open` flag to open docs after generation. Locally, docs are printed to `./target/doc/tidy/index.html`.
+Pull Requests welcome!
 
 ## Blog posts related to this project
 

--- a/src/display_information/mod.rs
+++ b/src/display_information/mod.rs
@@ -2,7 +2,7 @@
 
 pub mod uniquely_decodable;
 use crate::count_characters;
-use crate::display_information::uniquely_decodable::check_decodability;
+use crate::display_information::uniquely_decodable::is_uniquely_decodable;
 use crate::parse_delimiter;
 use crate::split_and_vectorize;
 
@@ -78,7 +78,10 @@ pub fn display_list_information(
 
     // At least for now, this one is EXPENSIVE
     if level >= 4 {
-        eprintln!("Uniquely decodable?       : {}", check_decodability(&list));
+        eprintln!(
+            "Uniquely decodable?       : {}",
+            is_uniquely_decodable(&list)
+        );
     }
 
     let entropy_per_word = calc_entropy_per_word(list.len());

--- a/src/display_information/uniquely_decodable.rs
+++ b/src/display_information/uniquely_decodable.rs
@@ -6,13 +6,11 @@
 /// very closely.
 use std::collections::HashSet;
 
-/// Return true if the list is uniquely decodable, false if not
+/// Return true if the list is uniquely decodable, false if not. I
+/// don't _think_ we need to check reversed words in this case.
 pub fn check_decodability(c: &[String]) -> bool {
-    let is_c_uniquely_decodable_forwards = sardinas_patterson_theorem(vec_to_hash(c));
-    // We need to check both forward and reverse
-    let c_reversed = reverse_all_words(c);
-    let is_c_uniquely_decodable_backwards = sardinas_patterson_theorem(vec_to_hash(&c_reversed));
-    is_c_uniquely_decodable_forwards || is_c_uniquely_decodable_backwards
+    let is_c_uniquely_decodable = sardinas_patterson_theorem(vec_to_hash(c));
+    is_c_uniquely_decodable
 }
 
 fn vec_to_hash(v: &[String]) -> HashSet<String> {
@@ -75,14 +73,6 @@ fn generate_c_infinity_with_a_halt_break(c: HashSet<String>) -> HashSet<String> 
         }
     }
     c_infinity
-}
-
-fn reverse_all_words(list: &[String]) -> Vec<String> {
-    let mut reversed_list = vec![];
-    for word in list {
-        reversed_list.push(word.chars().rev().collect::<String>());
-    }
-    reversed_list
 }
 
 /// Returns true if c is uniquely decodable

--- a/src/display_information/uniquely_decodable.rs
+++ b/src/display_information/uniquely_decodable.rs
@@ -8,9 +8,9 @@ use std::collections::HashSet;
 
 /// Return true if the list is uniquely decodable, false if not. I
 /// don't _think_ we need to check reversed words in this case.
-pub fn check_decodability(c: &[String]) -> bool {
-    let is_c_uniquely_decodable = sardinas_patterson_theorem(vec_to_hash(c));
-    is_c_uniquely_decodable
+pub fn is_uniquely_decodable(c: &[String]) -> bool {
+    let c = vec_to_hash(c);
+    sardinas_patterson_theorem(c)
 }
 
 fn vec_to_hash(v: &[String]) -> HashSet<String> {

--- a/src/display_information/uniquely_decodable.rs
+++ b/src/display_information/uniquely_decodable.rs
@@ -6,12 +6,13 @@
 /// very closely.
 use std::collections::HashSet;
 
+/// Return true if the list is uniquely decodable, false if not
 pub fn check_decodability(c: &[String]) -> bool {
-    // Right off the bat, convert inputted Slice to a HashSet
-    // Since we always want this list to be unique, and we're
-    // going to eventually calculate a disjoint boolean!
-    let c = vec_to_hash(c);
-    sardinas_patterson_theorem(c)
+    let is_c_uniquely_decodable_forwards = sardinas_patterson_theorem(vec_to_hash(c));
+    // We need to check both forward and reverse
+    let c_reversed = reverse_all_words(c);
+    let is_c_uniquely_decodable_backwards = sardinas_patterson_theorem(vec_to_hash(&c_reversed));
+    is_c_uniquely_decodable_forwards || is_c_uniquely_decodable_backwards
 }
 
 fn vec_to_hash(v: &[String]) -> HashSet<String> {
@@ -74,6 +75,14 @@ fn generate_c_infinity_with_a_halt_break(c: HashSet<String>) -> HashSet<String> 
         }
     }
     c_infinity
+}
+
+fn reverse_all_words(list: &[String]) -> Vec<String> {
+    let mut reversed_list = vec![];
+    for word in list {
+        reversed_list.push(word.chars().rev().collect::<String>());
+    }
+    reversed_list
 }
 
 /// Returns true if c is uniquely decodable

--- a/src/list_manipulations.rs
+++ b/src/list_manipulations.rs
@@ -88,7 +88,7 @@ pub fn delete_before_first_char(s: &str, ch: char) -> &str {
 /// [a separate repo](https://github.com/sts10/splitter/blob/main/src/lib.rs).
 pub fn delete_after_first_char(s: &str, ch: char) -> &str {
     match memchr(ch as u8, s.as_bytes()) {
-        None => s, // not found => return the whole string
+        None => s, // delimiting charcter not found in string s => return the whole string
         Some(pos) => &s[0..pos],
     }
 }

--- a/src/list_manipulations.rs
+++ b/src/list_manipulations.rs
@@ -141,20 +141,23 @@ pub fn guarantee_maximum_prefix_length(
 /// Executes Schlinkert prune. Attempts to make list uniquely decodable
 /// by removing the fewest number of code words possible. Adapted from
 /// Sardinas-Patterson algorithm.
-/// Runs word list in both as given and reversed, prefering which ever
-/// preserves more words from the given list.
+/// Runs word list both as given and with each word reversed, preferring
+/// which ever preserves more words from the given list.
 pub fn schlinkert_prune(list: &[String]) -> Vec<String> {
+    // Clumisily clone the list into a new variable.
+    let mut new_list = list.to_owned();
+    // First, simply find the "offenders" with the list as given.
     let offenders_to_remove_forwards = get_sardinas_patterson_final_intersection(list);
-    // Reversing all words before running the Schlinkert prune gives a
-    // different list of offending words. (We then have to un-reverse all the
-    // offending words.)
+    // Now, reverse all words before running the Schlinkert prune.
+    // This will give a different list of offending words -- and potentially FEWER
+    // than running the prune forwards. (We call reverse_all_words function
+    // twice because we have to un-reverse all the offending words at the end.)
     let offenders_to_remove_backwards = reverse_all_words(
         &get_sardinas_patterson_final_intersection(&reverse_all_words(list)),
     );
-    let mut new_list = list.to_owned();
     // If running the prune on the reversed words yielded fewer offenders
-    // we'll use that list, since our assumed goal is to remove the fewest
-    // number of words as possible.
+    // we'll remove those offending words, since our goal is to remove
+    // the fewest number of words as possible.
     if offenders_to_remove_forwards.len() <= offenders_to_remove_backwards.len() {
         new_list.retain(|x| !offenders_to_remove_forwards.contains(x));
     } else {

--- a/src/list_manipulations.rs
+++ b/src/list_manipulations.rs
@@ -88,7 +88,7 @@ pub fn delete_before_first_char(s: &str, ch: char) -> &str {
 /// [a separate repo](https://github.com/sts10/splitter/blob/main/src/lib.rs).
 pub fn delete_after_first_char(s: &str, ch: char) -> &str {
     match memchr(ch as u8, s.as_bytes()) {
-        None => s, // delimiting charcter not found in string s => return the whole string
+        None => s, // delimiting character not found in string s, so return the whole string
         Some(pos) => &s[0..pos],
     }
 }

--- a/src/list_manipulations.rs
+++ b/src/list_manipulations.rs
@@ -146,9 +146,11 @@ pub fn guarantee_maximum_prefix_length(
 pub fn schlinkert_prune(list: &[String]) -> Vec<String> {
     let offenders_to_remove_forwards = get_sardinas_patterson_final_intersection(list);
     // Reversing all words before running the Schlinkert prune gives a
-    // different list of offending words
-    let offenders_to_remove_backwards =
-        get_sardinas_patterson_final_intersection(&reverse_all_words(list));
+    // different list of offending words. (We then have to un-reverse all the
+    // offending words.)
+    let offenders_to_remove_backwards = reverse_all_words(
+        &get_sardinas_patterson_final_intersection(&reverse_all_words(list)),
+    );
     let mut new_list = list.to_owned();
     // If running the prune on the reversed words yielded fewer offenders
     // we'll use that list, since our assumed goal is to remove the fewest

--- a/src/list_manipulations.rs
+++ b/src/list_manipulations.rs
@@ -141,11 +141,36 @@ pub fn guarantee_maximum_prefix_length(
 /// Executes Schlinkert prune. Attempts to make list uniquely decodable
 /// by removing the fewest number of code words possible. Adapted from
 /// Sardinas-Patterson algorithm.
+/// Runs word list in both as given and reversed, prefering which ever
+/// preserves more words from the given list.
 pub fn schlinkert_prune(list: &[String]) -> Vec<String> {
-    let offenders_to_remove = get_sardinas_patterson_final_intersection(list);
+    let offenders_to_remove_forwards = get_sardinas_patterson_final_intersection(list);
+    // Reversing all words before running the Schlinkert prune gives a
+    // different list of offending words
+    let offenders_to_remove_backwards =
+        get_sardinas_patterson_final_intersection(&reverse_all_words(list));
     let mut new_list = list.to_owned();
-    new_list.retain(|x| !offenders_to_remove.contains(x));
+    // If running the prune on the reversed words yielded fewer offenders
+    // we'll use that list, since our assumed goal is to remove the fewest
+    // number of words as possible.
+    if offenders_to_remove_forwards.len() <= offenders_to_remove_backwards.len() {
+        new_list.retain(|x| !offenders_to_remove_forwards.contains(x));
+    } else {
+        new_list.retain(|x| !offenders_to_remove_backwards.contains(x));
+    }
     new_list
+}
+
+/// Reverse all words on given list
+/// ["hotdog", "hamburger", "alligator"] becomes
+/// ["godtoh", "regrubmah", "rotagilla"]
+/// Probably doesn't work well on complex graphmemes...
+fn reverse_all_words(list: &[String]) -> Vec<String> {
+    let mut reversed_list = vec![];
+    for word in list {
+        reversed_list.push(word.chars().rev().collect::<String>());
+    }
+    reversed_list
 }
 
 use unicode_segmentation::UnicodeSegmentation;

--- a/src/list_manipulations.rs
+++ b/src/list_manipulations.rs
@@ -144,7 +144,7 @@ pub fn guarantee_maximum_prefix_length(
 /// Runs word list both as given and with each word reversed, preferring
 /// which ever preserves more words from the given list.
 pub fn schlinkert_prune(list: &[String]) -> Vec<String> {
-    // Clumisily clone the list into a new variable.
+    // Clumsily clone the list into a new variable.
     let mut new_list = list.to_owned();
     // First, simply find the "offenders" with the list as given.
     let offenders_to_remove_forwards = get_sardinas_patterson_final_intersection(list);

--- a/src/list_manipulations.rs
+++ b/src/list_manipulations.rs
@@ -163,14 +163,14 @@ pub fn schlinkert_prune(list: &[String]) -> Vec<String> {
     new_list
 }
 
-/// Reverse all words on given list
-/// ["hotdog", "hamburger", "alligator"] becomes
-/// ["godtoh", "regrubmah", "rotagilla"]
-/// Probably doesn't work well on complex graphmemes...
-fn reverse_all_words(list: &[String]) -> Vec<String> {
+/// Reverse all words on given list. For example,
+/// `["hotdog", "hamburger", "alligator"]` becomes
+/// `["godtoh", "regrubmah", "rotagilla"]`
+/// Uses graphemes to ensure it handles accented characters correctly.
+pub fn reverse_all_words(list: &[String]) -> Vec<String> {
     let mut reversed_list = vec![];
     for word in list {
-        reversed_list.push(word.chars().rev().collect::<String>());
+        reversed_list.push(word.graphemes(true).rev().collect::<String>());
     }
     reversed_list
 }

--- a/tests/list_manipulation_tests.rs
+++ b/tests/list_manipulation_tests.rs
@@ -1,5 +1,6 @@
 mod list_manipulation_tests {
     use tidy::dice::print_as_dice; // not exactly sure why I need this here...
+    use tidy::list_manipulations::reverse_all_words;
     use tidy::*;
 
     fn make_lists() -> (Vec<String>, Vec<String>, Vec<String>, Vec<String>) {
@@ -658,6 +659,18 @@ mod list_manipulation_tests {
                 .chars()
                 .count()
         );
+    }
+
+    #[test]
+    fn can_reverse_list() {
+        let list = vec![
+            "hotdog".to_string(),
+            "hamburger".to_string(),
+            "alligator".to_string(),
+            "😀😁😆".to_string(),
+        ];
+        let rev_list = reverse_all_words(&list);
+        assert_eq!(rev_list, ["godtoh", "regrubmah", "rotagilla", "😆😁😀"]);
     }
 
     #[test]

--- a/tests/pruning_tests.rs
+++ b/tests/pruning_tests.rs
@@ -1,5 +1,5 @@
 mod pruning_tests {
-    use tidy::display_information::uniquely_decodable::check_decodability;
+    use tidy::display_information::uniquely_decodable::is_uniquely_decodable;
     use tidy::*;
 
     #[test]
@@ -32,6 +32,6 @@ mod pruning_tests {
         // And now let's confirm that the new list is indeed
         // uniquely decodable, at least as far as Tidy is able
         // to confirm.
-        assert!(check_decodability(&new_list));
+        assert!(is_uniquely_decodable(&new_list));
     }
 }

--- a/tests/pruning_tests.rs
+++ b/tests/pruning_tests.rs
@@ -1,0 +1,37 @@
+mod pruning_tests {
+    use tidy::display_information::uniquely_decodable::check_decodability;
+    use tidy::*;
+
+    #[test]
+    fn can_run_schlinkert_prune_on_reversed_list_if_it_saves_more_words() {
+        let list: Vec<String> = vec![
+            "news",
+            "paper",
+            "newspaper",
+            "donkey",
+            "newsdonkey",
+            "ghost",
+            "newsghost",
+            "radish",
+            "newsradish",
+        ]
+        .iter()
+        .map(|w| w.to_string())
+        .collect();
+
+        let this_tidy_request = TidyRequest {
+            list: list,
+            should_schlinkert_prune: true,
+            ..Default::default()
+        };
+        let new_list = tidy_list(this_tidy_request);
+        // If Schlinkert prune was done in forwards, only
+        // 5 words would be saved. But if we Schlinkert
+        // prune the reversed list, we save 8 words.
+        assert!(new_list.len() == 8);
+        // And now let's confirm that the new list is indeed
+        // uniquely decodable, at least as far as Tidy is able
+        // to confirm.
+        assert!(check_decodability(&new_list));
+    }
+}

--- a/tests/uniquely_decodable_tests.rs
+++ b/tests/uniquely_decodable_tests.rs
@@ -1,5 +1,5 @@
 mod uniquely_decodable_tests {
-    use tidy::display_information::uniquely_decodable::check_decodability;
+    use tidy::display_information::uniquely_decodable::is_uniquely_decodable;
 
     #[test]
     fn can_determine_a_list_with_prefix_words_is_not_uniquely_decodable() {
@@ -8,7 +8,7 @@ mod uniquely_decodable_tests {
             .map(|x| x.to_string())
             .collect();
 
-        assert!(!check_decodability(&list));
+        assert!(!is_uniquely_decodable(&list));
 
         let list2: Vec<String> = vec![
             "spill".to_string(),
@@ -17,7 +17,7 @@ mod uniquely_decodable_tests {
             "spills".to_string(),
             "unmoved".to_string(),
         ];
-        assert!(!check_decodability(&list2));
+        assert!(!is_uniquely_decodable(&list2));
     }
 
     #[test]
@@ -39,7 +39,7 @@ mod uniquely_decodable_tests {
         .iter()
         .map(|w| w.to_string())
         .collect();
-        assert!(check_decodability(&list));
+        assert!(is_uniquely_decodable(&list));
     }
 
     #[test]
@@ -48,7 +48,7 @@ mod uniquely_decodable_tests {
             .iter()
             .map(|w| w.to_string())
             .collect();
-        assert!(!check_decodability(&list));
+        assert!(!is_uniquely_decodable(&list));
     }
 
     #[test]
@@ -57,26 +57,26 @@ mod uniquely_decodable_tests {
             .iter()
             .map(|w| w.to_string())
             .collect();
-        assert!(check_decodability(&list));
+        assert!(is_uniquely_decodable(&list));
 
         let list: Vec<String> = vec!["0", "10", "010", "101"]
             .iter()
             .map(|w| w.to_string())
             .collect();
-        assert!(!check_decodability(&list));
+        assert!(!is_uniquely_decodable(&list));
 
         let list: Vec<String> = vec!["0", "01", "011", "0111"]
             .iter()
             .map(|w| w.to_string())
             .collect();
-        assert!(check_decodability(&list));
+        assert!(is_uniquely_decodable(&list));
 
         // '0, 1, 00, 11' is not an uniquely decodable code
         let list: Vec<String> = vec!["0", "1", "00", "11"]
             .iter()
             .map(|w| w.to_string())
             .collect();
-        assert!(!check_decodability(&list));
+        assert!(!is_uniquely_decodable(&list));
     }
 
     #[test]
@@ -87,6 +87,6 @@ mod uniquely_decodable_tests {
         .iter()
         .map(|w| w.to_string())
         .collect();
-        assert!(check_decodability(&list));
+        assert!(is_uniquely_decodable(&list));
     }
 }


### PR DESCRIPTION
Performs Schlinkert prune on given word list in both the direction it was provided _and_ in reverse. Why in reverse? Because (a) that is still a valid way to make a list uniquely decodable and (b) in some cases it saves more words from the original list ([BIPS39 English word list](https://github.com/bitcoin/bips/blob/master/bip-0039/english.txt) is such an example). 

## BIPS 39 word list as an example

If you perform a Schlinkert prune on the BIPS39 list in its given order, 1911 words are saved. If you reverse all words on the BIPS39 list and run a Schlinkert prune, 2011 words are saved. 

With this PR, when a user tells Tidy to do a Schlinkert prune (`-K`), it now does it in both directions and then actually executes whichever the one saves more words. Cool!

## Carefully reversing words with accented characters
Use graphemes!
```rust
/// Reverse all words on given list. For example,
/// `["hotdog", "hamburger", "alligator"]` becomes
/// `["godtoh", "regrubmah", "rotagilla"]`
/// Uses graphemes to ensure it handles accented characters correctly.
pub fn reverse_all_words(list: &[String]) -> Vec<String> {
    let mut reversed_list = vec![];
    for word in list {
        reversed_list.push(word.graphemes(true).rev().collect::<String>());
    }
    reversed_list
}
```

## Downsides

It does roughly double the time it takes to run a Schlinkert prune. But I think it's worth it if it does save more words. Tidy isn't built for speed, its built for thoroughness.