### PR TITLE
Adds option to print list attributes in JSON format

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "itoa"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
+
+[[package]]
 name = "libc"
 version = "0.2.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -631,10 +637,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.160"
+name = "ryu"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2f3770c8bce3bcda7e149193a069a0f4365bda1fa5cd88e03bca26afc1216c"
+checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
+
+[[package]]
+name = "serde"
+version = "1.0.163"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2113ab51b87a539ae008b5c6c02dc020ffa39afd2d83cffcb3f4eb2722cebec2"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.163"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c805777e3930c8883389c602315a24224bcc738b63905ef87cd1420353ea93e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.96"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "smallvec"
@@ -700,6 +737,8 @@ dependencies = [
  "memchr",
  "radix_fmt",
  "rand",
+ "serde",
+ "serde_json",
  "unicode-normalization",
  "unicode-segmentation",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -727,7 +727,7 @@ dependencies = [
 
 [[package]]
 name = "tidy"
-version = "0.2.92"
+version = "0.3.0"
 dependencies = [
  "clap",
  "icu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,5 @@ icu_collator = "1.2.0"
 icu = "1.2.0"
 icu_testdata = "1.2.0"
 unicode-segmentation = "1.10.1"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tidy"
-version = "0.2.92"
+version = "0.3.0"
 authors = ["sts10 <sschlinkert@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/readme.markdown
+++ b/readme.markdown
@@ -74,7 +74,7 @@ Options:
           amount of time to calculate
 
   -j, --json
-          Print attributes in JSON format
+          Print attributes and word samples in JSON format
 
   -s, --samples
           Print a handful of pseudorandomly selected words from the created list

--- a/readme.markdown
+++ b/readme.markdown
@@ -73,6 +73,9 @@ Options:
           once to print more attributes. Some attributes may take a nontrivial
           amount of time to calculate
 
+  -j, --json
+          Print attributes in JSON format
+
   -s, --samples
           Print a handful of pseudorandomly selected words from the created list
           to the terminal. Should NOT be used as secure passphrases

--- a/src/display_information/mod.rs
+++ b/src/display_information/mod.rs
@@ -82,7 +82,10 @@ fn make_attributes(list: &[String], level: u8, samples: bool) -> ListAttributes 
     };
 
     let longest_shared_prefix = if level >= 4 {
-        Some(find_longest_shared_prefix(list))
+        Some(find_longest_shared_prefix(
+            list,
+            Some(count_characters(&longest_word_example)),
+        ))
     } else {
         None
     };
@@ -362,14 +365,20 @@ pub fn find_mean_edit_distance(list: &[String]) -> f64 {
 /// Nested loops in this function get the `longest_shared_prefix`
 /// between any two words on the given list. Returns length of this
 /// longest shared prefix, a notable cryptographic metric.
-pub fn find_longest_shared_prefix(list: &[String]) -> usize {
+/// Optionally takes longest_word_length to speed up process.
+pub fn find_longest_shared_prefix(list: &[String], longest_word_length: Option<usize>) -> usize {
     let mut longest_shared_prefix = 0;
 
-    let longest_word_length = count_characters(
-        list.iter()
-            .max_by(|a, b| count_characters(a).cmp(&count_characters(b)))
-            .unwrap(),
-    );
+    // If longest_word_length is given, use that. If not,
+    // calculate it here.
+    let longest_word_length = match longest_word_length {
+        Some(longest_word_length) => longest_word_length,
+        None => count_characters(
+            list.iter()
+                .max_by(|a, b| count_characters(a).cmp(&count_characters(b)))
+                .unwrap(),
+        ),
+    };
     for word1 in list {
         for word2 in list {
             if word1 != word2 {

--- a/src/display_information/mod.rs
+++ b/src/display_information/mod.rs
@@ -29,8 +29,8 @@ pub struct ListAttributes {
     pub is_above_shannon_line: bool,
     pub shortest_edit_distance: Option<usize>,
     pub mean_edit_distance: Option<f64>,
-    pub longest_shared_prefix: usize,
-    pub unique_character_prefix: usize,
+    pub longest_shared_prefix: Option<usize>,
+    pub unique_character_prefix: Option<usize>,
     pub mcmillan: bool,
 }
 
@@ -64,8 +64,8 @@ fn make_attributes(list: &[String], level: u8) -> ListAttributes {
             is_uniquely_decodable: None,
             shortest_edit_distance: None,
             mean_edit_distance: None,
-            longest_shared_prefix: find_longest_shared_prefix(list),
-            unique_character_prefix: find_longest_shared_prefix(list) + 1,
+            longest_shared_prefix: None,
+            unique_character_prefix: None,
             mcmillan: satisfies_mcmillan(list),
         }
     } else if level == 2 {
@@ -86,8 +86,8 @@ fn make_attributes(list: &[String], level: u8) -> ListAttributes {
             is_uniquely_decodable: Some(is_uniquely_decodable(list)),
             shortest_edit_distance: None,
             mean_edit_distance: None,
-            longest_shared_prefix: find_longest_shared_prefix(list),
-            unique_character_prefix: find_longest_shared_prefix(list) + 1,
+            longest_shared_prefix: None,
+            unique_character_prefix: None,
             mcmillan: satisfies_mcmillan(list),
         }
     } else {
@@ -108,8 +108,8 @@ fn make_attributes(list: &[String], level: u8) -> ListAttributes {
             is_uniquely_decodable: Some(is_uniquely_decodable(list)),
             shortest_edit_distance: Some(find_shortest_edit_distance(list)),
             mean_edit_distance: Some(find_mean_edit_distance(list)),
-            longest_shared_prefix: find_longest_shared_prefix(list),
-            unique_character_prefix: find_longest_shared_prefix(list) + 1,
+            longest_shared_prefix: Some(find_longest_shared_prefix(list)),
+            unique_character_prefix: Some(find_longest_shared_prefix(list) + 1),
             mcmillan: satisfies_mcmillan(list),
         }
     }
@@ -218,20 +218,20 @@ pub fn display_list_information(
 
         if let Some(shortest_edit_distance) = list_attributes.shortest_edit_distance {
             eprintln!("Shortest edit distance    : {}", shortest_edit_distance)
-        };
+        }
         if let Some(mean_edit_distance) = list_attributes.mean_edit_distance {
             eprintln!("Mean edit distance        : {:.3}", mean_edit_distance)
         }
-        eprintln!(
-            "Longest shared prefix     : {}",
-            list_attributes.longest_shared_prefix
-        );
+
+        if let Some(longest_shared_prefix) = list_attributes.longest_shared_prefix {
+            eprintln!("Longest shared prefix     : {}", longest_shared_prefix)
+        }
         // Numbers of characters required to definitely get to a unique
         // prefix
-        eprintln!(
-            "Unique character prefix   : {}",
-            list_attributes.unique_character_prefix
-        );
+        if let Some(unique_character_prefix) = list_attributes.unique_character_prefix {
+            eprintln!("Unique character prefix   : {}", unique_character_prefix)
+        }
+
         if level >= 4 {
             let mcmillan = if list_attributes.mcmillan {
                 "satisfied"

--- a/src/display_information/mod.rs
+++ b/src/display_information/mod.rs
@@ -30,7 +30,7 @@ pub struct ListAttributes {
     pub shortest_edit_distance: Option<usize>,
     pub mean_edit_distance: Option<f64>,
     pub longest_shared_prefix: usize,
-    pub unqiue_character_prefix: usize,
+    pub unique_character_prefix: usize,
     pub mcmillan: bool,
 }
 
@@ -65,7 +65,7 @@ fn make_attributes(list: &[String], level: u8) -> ListAttributes {
             shortest_edit_distance: None,
             mean_edit_distance: None,
             longest_shared_prefix: find_longest_shared_prefix(list),
-            unqiue_character_prefix: find_longest_shared_prefix(list) + 1,
+            unique_character_prefix: find_longest_shared_prefix(list) + 1,
             mcmillan: satisfies_mcmillan(list),
         }
     } else if level == 2 {
@@ -87,7 +87,7 @@ fn make_attributes(list: &[String], level: u8) -> ListAttributes {
             shortest_edit_distance: None,
             mean_edit_distance: None,
             longest_shared_prefix: find_longest_shared_prefix(list),
-            unqiue_character_prefix: find_longest_shared_prefix(list) + 1,
+            unique_character_prefix: find_longest_shared_prefix(list) + 1,
             mcmillan: satisfies_mcmillan(list),
         }
     } else {
@@ -109,7 +109,7 @@ fn make_attributes(list: &[String], level: u8) -> ListAttributes {
             shortest_edit_distance: Some(find_shortest_edit_distance(list)),
             mean_edit_distance: Some(find_mean_edit_distance(list)),
             longest_shared_prefix: find_longest_shared_prefix(list),
-            unqiue_character_prefix: find_longest_shared_prefix(list) + 1,
+            unique_character_prefix: find_longest_shared_prefix(list) + 1,
             mcmillan: satisfies_mcmillan(list),
         }
     }
@@ -230,7 +230,7 @@ pub fn display_list_information(
         // prefix
         eprintln!(
             "Unique character prefix   : {}",
-            list_attributes.unqiue_character_prefix
+            list_attributes.unique_character_prefix
         );
         if level >= 4 {
             let mcmillan = if list_attributes.mcmillan {

--- a/src/display_information/mod.rs
+++ b/src/display_information/mod.rs
@@ -153,7 +153,7 @@ pub fn display_list_information(
     ignore_ending_metadata_delimiter: Option<char>,
     ignore_starting_metadata_delimiter: Option<char>,
 ) {
-    let list = make_list(
+    let list = make_list_free_of_metadata(
         list,
         ignore_starting_metadata_delimiter,
         ignore_ending_metadata_delimiter,
@@ -248,7 +248,7 @@ fn print_attributes_as_json(list_attributes: &ListAttributes) {
     eprintln!("{}", json);
 }
 
-fn make_list(
+fn make_list_free_of_metadata(
     list: &[String],
     ignore_ending_metadata_delimiter: Option<char>,
     ignore_starting_metadata_delimiter: Option<char>,

--- a/src/display_information/mod.rs
+++ b/src/display_information/mod.rs
@@ -31,7 +31,7 @@ pub struct ListAttributes {
     pub mean_edit_distance: Option<f64>,
     pub longest_shared_prefix: Option<usize>,
     pub unique_character_prefix: Option<usize>,
-    pub mcmillan: bool,
+    pub kraft_mcmillan: bool,
 }
 
 fn make_attributes(list: &[String], level: u8) -> ListAttributes {
@@ -107,7 +107,7 @@ fn make_attributes(list: &[String], level: u8) -> ListAttributes {
         mean_edit_distance,
         longest_shared_prefix,
         unique_character_prefix,
-        mcmillan: satisfies_mcmillan(list),
+        kraft_mcmillan: satisfies_kraft_mcmillan(list),
     }
 }
 
@@ -229,12 +229,12 @@ pub fn display_list_information(
         }
 
         if level >= 4 {
-            let mcmillan = if list_attributes.mcmillan {
+            let kraft_mcmillan = if list_attributes.kraft_mcmillan {
                 "satisfied"
             } else {
                 "not satisfied"
             };
-            eprintln!("Kraft-McMillan inequality : {}", mcmillan);
+            eprintln!("Kraft-McMillan inequality : {}", kraft_mcmillan);
         }
     }
 }
@@ -515,7 +515,7 @@ pub fn efficiency_per_character(list: &[String]) -> f64 {
 /// This function returns a bool based on whether the list fulfills something
 /// called the McMillan Inequality
 /// See: https://www.youtube.com/watch?v=yHw1ka-4g0s
-pub fn satisfies_mcmillan(list: &[String]) -> bool {
+pub fn satisfies_kraft_mcmillan(list: &[String]) -> bool {
     let alphabet_size = count_unique_characters(list);
     let mut running_total: f64 = 0.0;
     for word in list {

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -1,7 +1,6 @@
 use crate::cards::print_as_cards;
 use crate::dice::print_as_dice;
 use crate::display_information::display_list_information;
-use crate::display_information::generate_samples;
 use std::fs::File;
 use std::io::Write;
 use std::path::PathBuf;
@@ -73,36 +72,15 @@ pub fn print_list(print_req: PrintRequest) {
         } else if print_req.dry_run {
             eprintln!("Dry run complete");
         }
-        if print_req.attributes > 0 {
+        if print_req.attributes > 0 || print_req.samples {
             display_list_information(
                 &print_req.tidied_list,
                 print_req.attributes,
                 print_req.attributes_as_json,
                 print_req.ignore_after_delimiter,
                 print_req.ignore_before_delimiter,
+                print_req.samples,
             );
-        }
-        if print_req.samples {
-            let samples = generate_samples(
-                &print_req.tidied_list,
-                print_req.ignore_after_delimiter,
-                print_req.ignore_before_delimiter,
-            );
-            eprintln!("\nWord samples");
-            eprintln!("------------");
-            for n in 0..30 {
-                if n != 0 && n % 6 == 0 {
-                    // if we're at the end of the 6th word,
-                    // print a newline
-                    eprintln!();
-                } else if n != 0 {
-                    // else just print a space to go between each
-                    // word
-                    eprint!(" ");
-                }
-                eprint!("{}", samples[n]);
-            }
-            eprintln!();
         }
     }
 }

--- a/src/file_writer.rs
+++ b/src/file_writer.rs
@@ -16,6 +16,7 @@ pub struct PrintRequest {
     pub cards: bool,
     pub print_dice_sides_as_their_base: bool,
     pub attributes: u8,
+    pub attributes_as_json: bool,
     pub samples: bool,
     pub ignore_before_delimiter: Option<char>,
     pub ignore_after_delimiter: Option<char>,
@@ -76,6 +77,7 @@ pub fn print_list(print_req: PrintRequest) {
             display_list_information(
                 &print_req.tidied_list,
                 print_req.attributes,
+                print_req.attributes_as_json,
                 print_req.ignore_after_delimiter,
                 print_req.ignore_before_delimiter,
             );

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ struct Args {
     #[clap(short = 'A', long = "attributes", action = clap::ArgAction::Count)]
     attributes: u8,
 
-    /// Print attributes in JSON format
+    /// Print attributes and word samples in JSON format
     #[clap(short = 'j', long = "json")]
     attributes_as_json: bool,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,10 @@ struct Args {
     #[clap(short = 'A', long = "attributes", action = clap::ArgAction::Count)]
     attributes: u8,
 
+    /// Print attributes in JSON format
+    #[clap(short = 'j', long = "json")]
+    attributes_as_json: bool,
+
     /// Print a handful of pseudorandomly selected words from the created list
     /// to the terminal. Should NOT be used as secure passphrases.
     #[clap(short = 's', long = "samples")]
@@ -470,6 +474,7 @@ fn main() {
         dice_sides: opt.dice_sides,
         print_dice_sides_as_their_base: opt.print_dice_sides_as_their_base,
         attributes: opt.attributes,
+        attributes_as_json: opt.attributes_as_json,
         samples: opt.samples,
         ignore_before_delimiter,
         ignore_after_delimiter,

--- a/tests/list_information_tests.rs
+++ b/tests/list_information_tests.rs
@@ -85,6 +85,11 @@ mod list_information_tests {
         .map(|x| x.to_string())
         .collect();
         assert_eq!(find_longest_shared_prefix(&list), 7);
+        let list: Vec<String> = vec!["to", "canopy", "cancel", "seasons", "fire", "Christmas"]
+            .iter()
+            .map(|x| x.to_string())
+            .collect();
+        assert_eq!(find_longest_shared_prefix(&list), 3);
     }
     #[test]
     fn can_get_shortest_word_length() {

--- a/tests/list_information_tests.rs
+++ b/tests/list_information_tests.rs
@@ -84,12 +84,12 @@ mod list_information_tests {
         .iter()
         .map(|x| x.to_string())
         .collect();
-        assert_eq!(find_longest_shared_prefix(&list), 7);
+        assert_eq!(find_longest_shared_prefix(&list, None), 7);
         let list: Vec<String> = vec!["to", "canopy", "cancel", "seasons", "fire", "Christmas"]
             .iter()
             .map(|x| x.to_string())
             .collect();
-        assert_eq!(find_longest_shared_prefix(&list), 3);
+        assert_eq!(find_longest_shared_prefix(&list, None), 3);
     }
     #[test]
     fn can_get_shortest_word_length() {


### PR DESCRIPTION
As requested by @dmuth [here](https://github.com/sts10/wordlist-information/pull/3#issuecomment-1548620428), I hastily implemented a new `-j`/`--json` option for Tidy. 

If given, Tidy will print list attributes in JSON rather than formatted text. 

As we know, `tidy -AAA --dry-run eff_long-list.txt` (without the new `--json` option), you get: 
```
Attributes of new list
----------------------
List length               : 7776 words
Mean word length          : 6.99 characters
Length of shortest word   : 3 characters (aim)
Length of longest word    : 9 characters (zoologist)
Free of prefix words?     : true
Free of suffix words?     : false
Uniquely decodable?       : true
Entropy per word          : 12.925 bits
Efficiency per character  : 1.849 bits
Assumed entropy per char  : 4.308 bits
Above brute force line?   : true
Shortest edit distance    : 1
Mean edit distance        : 6.858
Longest shared prefix     : 8
Unique character prefix   : 9
```

But that's kind of rough for another program to parse. Let's print it in JSON!

With this PR, `tidy -AAA --dry-run --json eff_long_list.txt` prints: 
```text
{"list_length":7776,"mean_word_length":6.9917693,"entropy_per_word":12.92481250360578,"shortest_word_length":3,"shortest_word_example":"aim","longest_word_length":9,"longest_word_example":"zoologist","is_free_of_prefix_words":true,"is_free_of_suffix_words":false,"is_uniquely_decodable":true,"efficiency_per_character":1.848575363902923,"assumed_entropy_per_character":4.30827083453526,"is_above_brute_force_line":true,"is_above_shannon_line":false,"shortest_edit_distance":1,"mean_edit_distance":6.8580433818956505,"longest_shared_prefix":8,"unique_character_prefix":9,"mcmillan":true}
```

## Breaking Changes

I've also taken this opportunity to change the different "levels" of attributes and what they print. In general, I want `-A` to print list attributes that are nearly instantaneous to compute. Then, each "level" beyond 1 gives additional information that takes a bit longer to compute. 

One `-A` now prints
```
List length               : 7776 words
Mean word length          : 6.99 characters
Length of shortest word   : 3 characters (aim)
Length of longest word    : 9 characters (zoologist)
Entropy per word          : 12.925 bits
Efficiency per character  : 1.849 bits
Assumed entropy per char  : 4.308 bits
Above brute force line?   : true
Longest shared prefix     : 8
Unique character prefix   : 9
```

`-AA` now adds:
```
Free of prefix words?     : true
Free of suffix words?     : false
Uniquely decodable?       : true
```

`-AAA` gets you the edit distance info: 
```
Shortest edit distance    : 1
Mean edit distance        : 6.858
```

And 4 As `-AAAA` gets you the Shannon Line and Kraft-McMillan Inequality results, the rarest of attributes!
```
Above Shannon line?       : false
Kraft-McMillan inequality : satisfied
```

I'm definitely open to criticism about these "levels" and the _order_ of the attributes.