### PR TITLE
Be smarter about types when calculating mean edit distance to avoid a bug that might be an overflow

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -793,7 +793,7 @@ dependencies = [
 
 [[package]]
 name = "tidy"
-version = "0.3.5"
+version = "0.3.6"
 dependencies = [
  "clap",
  "icu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tidy"
-version = "0.3.5"
+version = "0.3.6"
 authors = ["sts10 <sschlinkert@gmail.com>"]
 edition = "2021"
 license = "MIT"

--- a/src/display_information/mod.rs
+++ b/src/display_information/mod.rs
@@ -357,8 +357,8 @@ fn find_shortest_edit_distance(list: &[String]) -> usize {
 
 /// Calculate the mean edit distance between all pairs of words on the list.
 pub fn find_mean_edit_distance(list: &[String]) -> f64 {
-    let mut sum_of_all_edit_distances = 0;
-    let mut number_of_edit_distances_measured = 0;
+    let mut sum_of_all_edit_distances: f64 = 0.0;
+    let mut number_of_edit_distances_measured: f64 = 0.0;
     for (i, word1) in list.iter().enumerate() {
         // The list[0..i] upper-bound in this inner loop is so that we don't do
         // twice as many calls as necessary. Otherwise we would be finding the
@@ -367,10 +367,14 @@ pub fn find_mean_edit_distance(list: &[String]) -> f64 {
         // distance to itself (0).
         for word2 in list[0..i].iter() {
             let this_edit_distance = find_edit_distance(word1, word2);
-            number_of_edit_distances_measured += 1;
-            sum_of_all_edit_distances += this_edit_distance as usize;
+            number_of_edit_distances_measured += 1.0;
+            sum_of_all_edit_distances += this_edit_distance as f64;
         }
     }
+    eprintln!(
+        "Number of edit distances recorded: {}\nSum of all edit distances: {}",
+        number_of_edit_distances_measured, sum_of_all_edit_distances
+    );
     (sum_of_all_edit_distances as f64) / (number_of_edit_distances_measured as f64)
 }
 

--- a/src/display_information/mod.rs
+++ b/src/display_information/mod.rs
@@ -375,7 +375,7 @@ pub fn find_mean_edit_distance(list: &[String]) -> f64 {
         "Number of edit distances recorded: {}\nSum of all edit distances: {}",
         number_of_edit_distances_measured, sum_of_all_edit_distances
     );
-    (sum_of_all_edit_distances as f64) / (number_of_edit_distances_measured as f64)
+    sum_of_all_edit_distances / number_of_edit_distances_measured
 }
 
 /// Nested loops in this function get the `longest_shared_prefix`
@@ -532,6 +532,7 @@ pub fn satisfies_kraft_mcmillan(list: &[String]) -> KraftMcmillanOutcome {
     }
 }
 
+/// Helper function for calculating the Kraft McMillian Inequality
 fn count_unique_characters(list: &[String]) -> usize {
     let mut characters = vec![];
     for word in list {


### PR DESCRIPTION
I believe this fixes #44. When I run `cargo run --release -- -AAA NSA-RandPassGenerator-wordlist.txt` ([this file](https://github.com/sts10/wordlist-information/blob/main/lists/NSA-RandPassGenerator-wordlist.txt)), instead of getting a negative number for mean edit distance, we get a much more plausible result of `7.719`.

The only remaining issue I have is I'm not 100% _why_ it fixes the issue. The only significant change is that we use `f64`s from the start of the function. But maybe that's enough?